### PR TITLE
Fix(dictionnary): Replace `lucide-react-native` with custom `CrossIcon`

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "expo-symbols": "~0.4.4",
     "expo-system-ui": "~5.0.7",
     "expo-web-browser": "~14.1.6",
-    "lucide-react-native": "^0.509.0",
     "metro": "^0.82.0",
     "nativewind": "^4.1.23",
     "react": "19.0.0",

--- a/src/app/(app)/sign/[sign].tsx
+++ b/src/app/(app)/sign/[sign].tsx
@@ -4,7 +4,7 @@ import { Sign } from "@/types/LessonInterface";
 import { router, useLocalSearchParams } from "expo-router";
 import { useEffect, useState } from "react";
 import { Text, Image, TouchableOpacity } from "react-native";
-import { ArrowLeft } from "lucide-react-native";
+import CrossIcon from"@assets/Courses/cross.svg";
 
 export default function SignScreen() {
   const { sign } = useLocalSearchParams();
@@ -40,7 +40,7 @@ export default function SignScreen() {
         onPress={() => router.push("/(app)/(tabs)/dictionary")}
         className="absolute top-8 left-4 bg-white/10 rounded-xl p-2"
       >
-        <ArrowLeft color="white" size={24} />
+        <CrossIcon width={30} height={30} />
       </TouchableOpacity>
 
       <Image


### PR DESCRIPTION
Removes the `lucide-react-native` dependency from the project and replaces its `ArrowLeft` icon usage with a custom `CrossIcon` SVG. This simplifies dependencies and enables the use of a custom icon design while maintaining similar functionality.