### PR TITLE
Replace react-native Image with expo-image via custom wrapper for cssInterop support

### DIFF
--- a/src/app/(app)/_layout.tsx
+++ b/src/app/(app)/_layout.tsx
@@ -1,10 +1,8 @@
 
-import AppView from '@/components/Ui/AppView';
 import Loading from '@/components/Ui/Loading';
 import { useAuth } from '@/context/AuthProvider';
 import { Redirect, Slot } from 'expo-router';
 import React from 'react';
-import { Text } from 'react-native';
 
 export default function LogLayout() {
   const {authState, loading} = useAuth();

--- a/src/app/(app)/lesson/[lesson].tsx
+++ b/src/app/(app)/lesson/[lesson].tsx
@@ -6,7 +6,6 @@ import { getLessonById } from '@/services/lessonsServices';
 import { LessonProgress, LessonWithExercises } from '@/types/LessonInterface';
 import { router, useLocalSearchParams } from 'expo-router';
 import { useCallback, useEffect, useState } from 'react';
-import { View, Text } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 export default function LessonScreen() {

--- a/src/app/(app)/sign/[sign].tsx
+++ b/src/app/(app)/sign/[sign].tsx
@@ -3,9 +3,10 @@ import { getSignByName } from "@/services/dictionnaryServices";
 import { Sign } from "@/types/LessonInterface";
 import { router, useLocalSearchParams } from "expo-router";
 import { useEffect, useState } from "react";
-import { Text, Image, TouchableOpacity } from "react-native";
+import { Text, TouchableOpacity } from "react-native";
 import CrossIcon from"@assets/Courses/cross.svg";
 import Loading from "@/components/Ui/Loading";
+import Image from "@/components/Ui/Image";
 
 export default function SignScreen() {
   const { sign } = useLocalSearchParams();
@@ -43,7 +44,8 @@ export default function SignScreen() {
       </TouchableOpacity>
 
       <Image
-        source={{ uri: signDisplayed?.mediaUrl }}
+        source={signDisplayed?.mediaUrl}
+        contentFit="cover"
         className="w-60 h-60 rounded-xl mb-6"
       />
 

--- a/src/components/Lessons/Exercises/ImageToWord.tsx
+++ b/src/components/Lessons/Exercises/ImageToWord.tsx
@@ -3,8 +3,9 @@ import { checkExercise } from "@/services/exercisesServices";
 import { ExerciseWithSign } from "@/types/LessonInterface";
 import { router } from "expo-router";
 import { useEffect, useMemo, useState } from "react";
-import { Image, TouchableOpacity} from "react-native";
+import { TouchableOpacity} from "react-native";
 import AppText from "@/components/Ui/AppText";
+import Image from "@/components/Ui/Image";
 
 interface ImageToWordProps {
     onNext: () => void;

--- a/src/components/Lessons/Exercises/PlayExercise.tsx
+++ b/src/components/Lessons/Exercises/PlayExercise.tsx
@@ -2,7 +2,7 @@ import { getExerciseById } from "@/services/exercisesServices";
 import { Exercise, ExerciseWithSign } from "@/types/LessonInterface";
 import { router } from "expo-router";
 import { useEffect, useState } from "react";
-import { Text, View } from "react-native";
+import { View } from "react-native";
 import WordToImage from "./WordToImage";
 import ImageToWord from "./ImageToWord";
 import Loading from "@/components/Ui/Loading";

--- a/src/components/Lessons/Exercises/WordToImage.tsx
+++ b/src/components/Lessons/Exercises/WordToImage.tsx
@@ -4,10 +4,11 @@ import { checkExercise } from "@/services/exercisesServices";
 import { ExerciseWithSign } from "@/types/LessonInterface";
 import { router } from "expo-router";
 import { useEffect, useMemo, useState } from "react";
-import { Image, TouchableOpacity } from "react-native";
+import { TouchableOpacity } from "react-native";
 import { responseStatus } from "./ImageToWord";
 import AppText from "@/components/Ui/AppText";
 import Loading from "@/components/Ui/Loading";
+import Image from "@/components/Ui/Image";
 
 interface WordToImageProps {
     onNext: () => void;

--- a/src/components/Lessons/PlayLesson.tsx
+++ b/src/components/Lessons/PlayLesson.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useState } from "react";
 import AppView from "../Ui/AppView";
-import { Text } from "react-native";
 import { completeLessonProgress, resetLessonProgress, startLessonProgress, updateLessonProgress } from "@/services/lessonProgressServices";
 import { Exercise, LessonProgress, LessonWithExercises } from "@/types/LessonInterface";
 import { router } from "expo-router";

--- a/src/components/Ui/Image.tsx
+++ b/src/components/Ui/Image.tsx
@@ -1,0 +1,15 @@
+import { Image as ExpoImage, ImageProps } from 'expo-image';
+import { cssInterop } from 'nativewind';
+
+
+const Image: React.FC<ImageProps> = (props) => {
+    cssInterop(ExpoImage, {className: "style",});
+
+    return (
+    <ExpoImage
+        {...props}
+    />
+  );
+};
+
+export default Image;

--- a/src/components/Ui/Loading.tsx
+++ b/src/components/Ui/Loading.tsx
@@ -11,7 +11,7 @@ const Loading: React.FC = () => {
       withTiming(360, { duration: 1000, easing: Easing.linear }),
       -1
     );
-  }, []);
+  }, [rotation]);
 
   const animatedStyle = useAnimatedStyle(() => ({
     transform: [{ rotate: `${rotation.value}deg` }],


### PR DESCRIPTION
This PR replaces all usages of the default Image component from react-native with a custom wrapper around expo-image, enabling support for animated formats (like GIFs) and improved performance (better caching and rendering).
To ensure compatibility with Tailwind CSS via cssInterop, the expo-image component has been encapsulated in a new <AppImage> component.